### PR TITLE
Add history API endpoint

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
-const fetch = require( 'node-fetch' );
-const Paletas = require( './src/scripts/palette' );
+const fetch = require( "node-fetch" );
+const Paletas = require( "./src/scripts/palette" );
 
 module.exports = function( config )
 {
@@ -12,7 +12,7 @@ module.exports = function( config )
 		let url = process.env.HISTORY_URL;
 		if( !url )
 		{
-			console.log( '👻 Skipping /api/history.json' );
+			console.log( "👻 Skipping /api/history.json" );
 			return [];
 		}
 
@@ -36,7 +36,7 @@ module.exports = function( config )
 		let availableItems = allItems
 			.filter( collectionItem =>
 			{
-				return !Paletas.historyContains( history, collectionItem )
+				return !Paletas.historyContains( history, collectionItem );
 			});
 
 		let maxLength = Math.floor( allItems.length / 2 );
@@ -94,23 +94,23 @@ module.exports = function( config )
 	 * Filters
 	 */
 
-	config.addFilter( 'api', collection =>
+	config.addFilter( "api", collection =>
 	{
 		return collection.map( item => Paletas.api( item ) );
 	});
 
-	config.addFilter( 'jsonify', items =>
+	config.addFilter( "jsonify", items =>
 	{
 		return JSON.stringify( items, null, 2 );
 	});
 
-	config.addFilter( 'textify', collection =>
+	config.addFilter( "textify", collection =>
 	{
-		let text = '';
+		let text = "";
 
 		collection.forEach( item =>
 		{
-			text += `# ${item.data.title}\n# Submitted by ${item.data.author}\n${item.data.colors.join( ',' )}\n\n`
+			text += `# ${item.data.title}\n# Submitted by ${item.data.author}\n${item.data.colors.join( "," )}\n\n`;
 		});
 
 		return text.trim();

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,57 @@
+const fetch = require( 'node-fetch' );
+const Paletas = require( './src/scripts/palette' );
+
 module.exports = function( config )
 {
+	/*
+	 * Collections
+	 */
+
+	config.addCollection( "history", async (collection) =>
+	{
+		let url = process.env.HISTORY_URL;
+		if( !url )
+		{
+			console.log( '👻 Skipping /api/history.json' );
+			return [];
+		}
+
+		let history = [];
+		let res = await fetch( url );
+
+		try
+		{
+			history = await res.json();
+		}
+		catch( error )
+		{
+			// We expect invalid JSON in the absence of a valid URL (ex., this
+			// is the first history item)
+		}
+
+		let allItems = collection
+			.getFilteredByGlob( "src/palettes/*.md" )
+			.filter( palette => !palette.data.disabled );
+
+		let availableItems = allItems
+			.filter( collectionItem =>
+			{
+				return !Paletas.historyContains( history, collectionItem )
+			});
+
+		let maxLength = Math.floor( allItems.length / 2 );
+		if( history.length >= maxLength )
+		{
+			history.pop();
+		}
+
+		let randomIndex = Math.floor( Math.random() * availableItems.length );
+		let randomItem = availableItems[randomIndex];	
+		history.unshift( Paletas.api( randomItem ) );
+
+		return history;
+	});
+
 	config.addCollection( "palettes", collection =>
 	{
 		let palettes = collection
@@ -38,18 +90,17 @@ module.exports = function( config )
 		return palettes;
 	});
 
-	config.addFilter( 'jsonify', collection =>
-	{
-		let items = collection.map( item =>
-		{
-			return {
-				title: item.data.title,
-				author: item.data.author,
-				colors: item.data.colors.map( color => color.toString() ),
-				date: item.data.date,
-			};
-		});
+	/*
+	 * Filters
+	 */
 
+	config.addFilter( 'api', collection =>
+	{
+		return collection.map( item => Paletas.api( item ) );
+	});
+
+	config.addFilter( 'jsonify', items =>
+	{
 		return JSON.stringify( items, null, 2 );
 	});
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -39,15 +39,15 @@ module.exports = function( config )
 				return !Paletas.historyContains( history, collectionItem );
 			});
 
+		let randomIndex = Math.floor( Math.random() * availableItems.length );
+		let randomItem = availableItems[randomIndex];
+		history.unshift( Paletas.api( randomItem ) );
+
 		let maxLength = Math.floor( allItems.length / 2 );
 		if( history.length >= maxLength )
 		{
-			history.pop();
+			history = history.slice( 0, maxLength );
 		}
-
-		let randomIndex = Math.floor( Math.random() * availableItems.length );
-		let randomItem = availableItems[randomIndex];	
-		history.unshift( Paletas.api( randomItem ) );
 
 		return history;
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,6 +3440,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-source-walk": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:lint": "eslint **/**.js --ignore-pattern '!.eleventy.js'"
   },
   "dependencies": {
-    "@11ty/eleventy": "^0.8.3"
+    "@11ty/eleventy": "^0.8.3",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "eslint": "^6.1.0"

--- a/src/_includes/api/json.njk
+++ b/src/_includes/api/json.njk
@@ -1,1 +1,1 @@
-{{ collections.palettes | jsonify | safe }}
+{{ collections.palettes | api | jsonify | safe }}

--- a/src/_includes/history.njk
+++ b/src/_includes/history.njk
@@ -1,0 +1,1 @@
+{{ collections.history | jsonify | safe }}

--- a/src/api/history.md
+++ b/src/api/history.md
@@ -1,0 +1,4 @@
+---
+layout: history.njk
+permalink: api/history.json
+---

--- a/src/scripts/palette.js
+++ b/src/scripts/palette.js
@@ -20,7 +20,7 @@ module.exports.historyContains = (jsonHistory, collectionItem) =>
 {
 	let match = jsonHistory.find( element =>
 	{
-		return element.slug === collectionItem.data.page.fileSlug
+		return element.slug === collectionItem.data.page.fileSlug;
 	});
 
 	return match !== undefined;

--- a/src/scripts/palette.js
+++ b/src/scripts/palette.js
@@ -1,0 +1,27 @@
+/**
+ * @param {Object} collectionItem - A single Eleventy collection item
+ */
+module.exports.api = (collectionItem) =>
+{
+	return {
+		title: collectionItem.data.title,
+		author: collectionItem.data.author,
+		slug: collectionItem.data.page.fileSlug,
+		colors: collectionItem.data.colors.map( color => color.toString() ),
+	};
+};
+
+/**
+ * @param {Object} jsonHistory
+ * @param {Object} collectionItem - A single Eleventy collection item
+ * @return {Boolean}
+ */
+module.exports.historyContains = (jsonHistory, collectionItem) =>
+{
+	let match = jsonHistory.find( element =>
+	{
+		return element.slug === collectionItem.data.page.fileSlug
+	});
+
+	return match !== undefined;
+};


### PR DESCRIPTION
## Description

The endpoint returns a JSON array of palette definitions, in descending order of most recently used. The contents are updated at build time, adding a palette which is not already present. The length is capped at half the number of enabled palettes, slicing elements off the end of the array as necessary.
    
This endpoint is designed to be consumed by the skyline generation script, which should only use the 0th element. This will ensure that palettes do not reappear on the bot's timeline until a significant number of other palettes have been used.

## Usage

```
HISTORY_URL=https://paletas.ashur.cab/api/history.json npm run build
```

If `process.env.HISTORY_URL` is defined at build time, the URL is fetched and treated as the existing history. A random, unused palette is added, and the array is trimmed to size. The resulting array is built to `/api/history.json`, making it available for the next build.