### PR TITLE
rainbow flag palette by martiros sarian

### DIFF
--- a/src/palettes/sarian-flag.md
+++ b/src/palettes/sarian-flag.md
@@ -1,0 +1,12 @@
+---
+title: Sarian Flag
+author: Norayr Chilingarian
+colors:
+  - "b11f38"
+  - "e77a3d"
+  - "ebd524"
+  - "4aa77a"
+  - "685b87"
+  - "a24c57"
+source: https://en.m.wikipedia.org/wiki/Rainbow_flag#Armenian_Republic_proposed_flag_(1919)
+---


### PR DESCRIPTION
Rainbow flag proposed after Armenia regained independence after World War I. It was designed by famous Armenian artist Martiros Saryan. It was not adopted as the country instead went with three stripes using the colors used in a past Armenian kingdom. The artists used muted, richer colors reflecting Armenian fabrics and carpets.